### PR TITLE
Add code to deploy rbac proxy

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,8 +14,14 @@ docs: https://discourse.charmhub.io/t/8212
 containers:
   pvcviewer-operator:
     resource: oci-image
+  kube-rbac-proxy:
+    resource: oci-image-proxy
 resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
     upstream-source: docker.io/kubeflownotebookswg/pvcviewer-controller:v1.8.0-rc.1
+  oci-image-proxy:
+    type: oci-image
+    description: OCI image for kube rbac proxy
+    upstream-source: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1

--- a/src/components/pebble_component.py
+++ b/src/components/pebble_component.py
@@ -23,7 +23,30 @@ class PvcViewerPebbleService(PebbleServiceComponent):
                     self.service_name: {
                         "override": "replace",
                         "summary": "Entry point for pvcviewer image",
-                        "command": "/manager --leader-elect",
+                        "command": "/manager --health-probe-bind-address=:8081 --metrics-bind-address=127.0.0.1:8080 --leader-elect",  # noqa: E501
+                        "startup": "enabled",
+                    }
+                },
+            }
+        )
+
+
+class RbacProxyPebbleService(PebbleServiceComponent):
+    def get_layer(self) -> Layer:
+        """Defines and returns Pebble layer configuration
+
+        This method is required for subclassing PebbleServiceContainer
+        """
+        logger.info("PebbleServiceComponent.get_layer executing")
+        return Layer(
+            {
+                "summary": "kube rbac proxy layer",
+                "description": "Pebble config layer for kube rbac proxy",
+                "services": {
+                    self.service_name: {
+                        "override": "replace",
+                        "summary": "Entry point for kube rbac proxy image",
+                        "command": "/usr/local/bin/kube-rbac-proxy --secure-listen-address=0.0.0.0:8443 --upstream=http://127.0.0.1:8080/ --logtostderr=true --v=0",  # noqa: E501
                         "startup": "enabled",
                     }
                 },

--- a/src/templates/auth_manifests.yaml.j2
+++ b/src/templates/auth_manifests.yaml.j2
@@ -3,22 +3,46 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: {{ app_name }}
   name: {{ app_name }}
   namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-metrics-reader
 rules:
 - nonResourceURLs:
-  - "/metrics"
+  - /metrics
   verbs:
   - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -32,6 +56,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-proxy-role
 rules:
 - apiGroups:
@@ -50,6 +82,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-leader-election-rolebinding
   namespace: {{ namespace }}
 roleRef:
@@ -65,6 +105,14 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-leader-election-role
   namespace: {{ namespace }}
 rules:
@@ -103,6 +151,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -116,7 +172,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
+  labels:
+    app: {{ app_name }}
   name: pvcviewer-role
 rules:
 - apiGroups:

--- a/src/templates/auth_manifests.yaml.j2
+++ b/src/templates/auth_manifests.yaml.j2
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: controller-manager-sa
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/part-of: {{ app_name }}
   name: {{ app_name }}
@@ -22,7 +21,6 @@ metadata:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-metrics-reader
@@ -40,7 +38,6 @@ metadata:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: proxy-rolebinding
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-proxy-rolebinding
@@ -61,7 +58,6 @@ metadata:
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: proxy-role
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-proxy-role
@@ -87,7 +83,6 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: leader-election-rolebinding
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-leader-election-rolebinding
@@ -110,7 +105,6 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: leader-election-role
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: role
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-leader-election-role
@@ -156,7 +150,6 @@ metadata:
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: manager-rolebinding
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-manager-rolebinding

--- a/src/templates/crd_manifests.yaml.j2
+++ b/src/templates/crd_manifests.yaml.j2
@@ -3,10 +3,22 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    cert-manager.io/inject-ca-from: kubeflow/pvcviewer-serving-cert
     controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
+  labels:
+    app: {{ app_name }}
   name: pvcviewers.kubeflow.org
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: {{ webhook_service_name }}
+          namespace: {{ namespace }}
+          path: /convert
+      conversionReviewVersions:
+      - v1
   group: kubeflow.org
   names:
     kind: PVCViewer

--- a/src/templates/webhook_manifests.yaml.j2
+++ b/src/templates/webhook_manifests.yaml.j2
@@ -1,6 +1,16 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/pvcviewer-serving-cert
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: mutating-webhook-configuration
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: mutatingwebhookconfiguration
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -28,6 +38,16 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubeflow/pvcviewer-serving-cert
+  labels:
+    app: {{ app_name }}
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: {{ app_name }}
+    app.kubernetes.io/instance: validating-webhook-configuration
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: validatingwebhookconfiguration
+    app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/src/templates/webhook_manifests.yaml.j2
+++ b/src/templates/webhook_manifests.yaml.j2
@@ -8,7 +8,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: mutating-webhook-configuration
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: mutatingwebhookconfiguration
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-mutating-webhook-configuration
@@ -45,7 +44,6 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: {{ app_name }}
     app.kubernetes.io/instance: validating-webhook-configuration
-    app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/name: validatingwebhookconfiguration
     app.kubernetes.io/part-of: {{ app_name }}
   name: pvcviewer-validating-webhook-configuration

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -115,7 +115,8 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     charm_under_test = await ops_test.build_charm(".")
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]
-    resources = {"oci-image": image_path}
+    image_path_proxy = METADATA["resources"]["oci-image-proxy"]["upstream-source"]
+    resources = {"oci-image": image_path, "oci-image-proxy": image_path_proxy}
     await ops_test.model.deploy(
         charm_under_test, resources=resources, application_name=CHARM_NAME, trust=True
     )

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -74,6 +74,7 @@ def test_pebble_services_running(
     # Arrange
     harness.begin()
     harness.set_can_connect("pvcviewer-operator", True)
+    harness.set_can_connect("kube-rbac-proxy", True)
 
     # Mock:
     # * leadership_gate to have get_status=>Active
@@ -87,8 +88,11 @@ def test_pebble_services_running(
 
     # Assert
     container = harness.charm.unit.get_container("pvcviewer-operator")
+    container_rbac_proxy = harness.charm.unit.get_container("kube-rbac-proxy")
     service = container.get_service("pvcviewer-operator")
+    service_rbac_proxy = container_rbac_proxy.get_service("kube-rbac-proxy")
     assert service.is_running()
+    assert service_rbac_proxy.is_running()
 
 
 def test_get_certs(harness, mocked_lightkube_client, mocked_kubernetes_service_patch):


### PR DESCRIPTION
Fixes https://github.com/canonical/pvcviewer-operator/issues/14

The charm was missing kube-rbac-proxy image with setup. 

Changes:
- deploy kube-rbac-proxy 
- rbac-proxy image is correctly set 
- add service for kube-rbac-proxy (same service as operator just another port)
- add tests