### PR TITLE
pin integration test dependencies for `track/1.8`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,9 +55,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Maximise GH runner space
-      uses: easimon/maximize-build-space@v8
+      uses: easimon/maximize-build-space@v7
       with:
-        root-reserve-mb: 40960
+        root-reserve-mb: 29696
         remove-dotnet: 'true'
         remove-haskell: 'true'
         remove-android: 'true'

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,8 +23,8 @@ CHARM_NAME = METADATA["name"]
 
 ISTIO_GATEWAY_CHARM_NAME = "istio-gateway"
 ISTIO_PILOT_CHARM_NAME = "istio-pilot"
-ISTIO_PILOT_VERSION = "1.16/stable"
-ISTIO_GATEWAY_VERSION = "1.16/stable"
+ISTIO_PILOT_VERSION = "1.17/stable"
+ISTIO_GATEWAY_VERSION = "1.17/stable"
 ISTIO_GATEWAY_NAME = "kubeflow-gateway"
 EXAMPLE_FILE = "./tests/integration/pvcviewer_example/pvcviewer_example.yaml"
 EXAMPLE_PATH = "/pvcviewer/kubeflow-user-example-com/pvcviewer-sample/files/"


### PR DESCRIPTION
Pins dependencies in the integration tests to their corresponding channels for this release.

Ref: https://github.com/canonical/bundle-kubeflow/issues/866
