### PR TITLE
feat: add get images script

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
## Summary
Create a script that will parse the metadata.yaml that contain references to the images used by the charm.

Related to https://github.com/canonical/bundle-kubeflow/issues/889.
This script is used by the [`get-all-images.sh`](https://github.com/canonical/bundle-kubeflow/blob/main/scripts/airgapped/get-all-images.sh) script.