### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -67,7 +67,7 @@ jobs:
     - name: Setup operator environment
       uses: charmed-kubernetes/actions-operator@1.1.0
       with:
-        juju-channel: 3.5/stable
+        juju-channel: 3.4/stable
         provider: microk8s
         channel: 1.25-strict/stable
         microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944