### PR TITLE
chore: bump pvcviewer to v1.9.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: docker.io/kubeflownotebookswg/pvcviewer-controller:v1.9.0-rc.0
+    upstream-source: docker.io/kubeflownotebookswg/pvcviewer-controller:v1.9.0
 requires:
   logging:
     interface: loki_push_api


### PR DESCRIPTION
closes #47 
brings in the changes from https://github.com/kubeflow/manifests/tree/v1.9.0