### PR TITLE
ci(upload-charm): use charmcraft from latest/candidate

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,3 +12,4 @@ jobs:
     name: Publish
     uses: canonical/charmed-kubeflow-workflows/.github/workflows/_publish.yaml@main
     secrets: inherit
+          charmcraft-channel: latest/candidate


### PR DESCRIPTION
Use charmcraft from latest/candidate in upload-charm in order to unify the channel used during integration tests and publishing.
  Ref canonical/bundle-kubeflow#993