### PR TITLE
chore: bump pvcviewer to v1.10.0-rc.1

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: docker.io/kubeflownotebookswg/pvcviewer-controller:v1.9.0
+    upstream-source: docker.io/kubeflownotebookswg/pvcviewer-controller:v1.10.0-rc.1
 requires:
   logging:
     interface: loki_push_api


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-6872

Updates the pvcviewer image to `v1.10.0-rc.1`.
There were no changes in manifests, see https://github.com/kubeflow/manifests/tree/v1.10.0-rc.1/apps/pvcviewer-controller/upstream.