### PR TITLE
chore: Update manifests and integrate rocks for 1.10

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/pvcviewer-controller:1.10.0-rc.1-3a8beff
+    upstream-source: charmedkubeflow/pvcviewer-controller:1.10.0-09b616ff
 requires:
   logging:
     interface: loki_push_api

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,7 +18,7 @@ resources:
   oci-image:
     type: oci-image
     description: Backing OCI image
-    upstream-source: charmedkubeflow/pvcviewer-controller:1.10.0-09b616ff
+    upstream-source: charmedkubeflow/pvcviewer-controller:1.10.0-09b616f
 requires:
   logging:
     interface: loki_push_api


### PR DESCRIPTION
This PR integrates the newest version of the rock, and the final one for the CKF 1.10 release.

To view if there were any miscellaneous manifest changes, I compared the 2 tags: https://github.com/kubeflow/manifests/compare/v1.10.0-rc.2...v1.10.0-rc.3