### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -38,7 +38,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -67,7 +67,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -1,0 +1,13 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+ISTIO_GATEWAY = CharmSpec(
+    charm="istio-gateway", channel="latest/edge", config={"kind": "ingress"}, trust=True
+)
+ISTIO_PILOT = CharmSpec(
+    charm="istio-pilot",
+    channel="latest/edge",
+    config={"default-gateway": "kubeflow-gateway"},
+    trust=True,
+)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -17,6 +17,7 @@ from charmed_kubeflow_chisme.testing import (
     deploy_and_assert_grafana_agent,
     get_alert_rules,
 )
+from charms_dependencies import ISTIO_GATEWAY, ISTIO_PILOT
 from lightkube import codecs
 from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.core_v1 import Service
@@ -28,11 +29,6 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_NAME = METADATA["name"]
 
-ISTIO_GATEWAY_CHARM_NAME = "istio-gateway"
-ISTIO_PILOT_CHARM_NAME = "istio-pilot"
-ISTIO_PILOT_VERSION = "latest/edge"
-ISTIO_GATEWAY_VERSION = "latest/edge"
-ISTIO_GATEWAY_NAME = "kubeflow-gateway"
 EXAMPLE_FILE = "./tests/integration/pvcviewer_example/pvcviewer_example.yaml"
 EXAMPLE_PATH = "/pvcviewer/kubeflow-user-example-com/pvcviewer-sample/files/"
 
@@ -100,21 +96,21 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     # Deploy istio-operators for ingress configuration
     await ops_test.model.deploy(
-        ISTIO_PILOT_CHARM_NAME,
-        channel=ISTIO_PILOT_VERSION,
-        config={"default-gateway": ISTIO_GATEWAY_NAME},
-        trust=True,
+        ISTIO_PILOT.charm,
+        channel=ISTIO_PILOT.channel,
+        config=ISTIO_PILOT.config,
+        trust=ISTIO_PILOT.trust,
     )
 
     await ops_test.model.deploy(
-        ISTIO_GATEWAY_CHARM_NAME,
-        channel=ISTIO_GATEWAY_VERSION,
-        config={"kind": "ingress"},
-        trust=True,
+        ISTIO_GATEWAY.charm,
+        channel=ISTIO_GATEWAY.channel,
+        config=ISTIO_GATEWAY.config,
+        trust=ISTIO_GATEWAY.trust,
     )
-    await ops_test.model.integrate(ISTIO_PILOT_CHARM_NAME, ISTIO_GATEWAY_CHARM_NAME)
+    await ops_test.model.integrate(ISTIO_PILOT.charm, ISTIO_GATEWAY.charm)
     await ops_test.model.wait_for_idle(
-        [ISTIO_PILOT_CHARM_NAME, ISTIO_GATEWAY_CHARM_NAME],
+        [ISTIO_PILOT.charm, ISTIO_GATEWAY.charm],
         raise_on_blocked=False,
         status="active",
         timeout=900,


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
