### PR TITLE
chore: Update CI to use Canonical K8s

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,17 +70,17 @@ jobs:
         remove-codeql: 'true'
         remove-docker-images: 'true'
     - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: pipx install tox
+    - name: Install dependencies
+      run: pipx install tox
 
-      - name: Setup environment
-        run: |
-          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
-          sudo rm -rf /run/containerd
-          sudo snap install concierge --classic
-          sudo concierge prepare --trace
+    - name: Setup environment
+      run: |
+        sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+        sudo rm -rf /run/containerd
+        sudo snap install concierge --classic
+        sudo concierge prepare --trace
     - name: Run integration tests
-      run: tox -vve integration -- --model kubeflow
+      run: tox -vve integration
 
     # On failure, capture debugging resources      
     - name: Get all

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -80,7 +80,7 @@ jobs:
           sudo snap install concierge --classic
           sudo concierge prepare --trace
     - name: Run integration tests
-      run: tox -vve integration -- --model kubeflow
+      run: tox -vve integration
 
     # On failure, capture debugging resources      
     - name: Get all

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,16 +70,15 @@ jobs:
         remove-codeql: 'true'
         remove-docker-images: 'true'
     - uses: actions/checkout@v4
-    - name: Setup operator environment
-      uses: charmed-kubernetes/actions-operator@main
-      with:
-        juju-channel: 3.6/stable
-        provider: microk8s
-        channel: 1.32-strict/stable
-        microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-        charmcraft-channel: 3.x/stable
+      - name: Install dependencies
+        run: pipx install tox
 
-    # Running with kubeflow model because of upstream issue https://github.com/kubeflow/kubeflow/issues/7283
+      - name: Setup environment
+        run: |
+          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+          sudo rm -rf /run/containerd
+          sudo snap install concierge --classic
+          sudo concierge prepare --trace
     - name: Run integration tests
       run: tox -vve integration -- --model kubeflow
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -80,7 +80,7 @@ jobs:
           sudo snap install concierge --classic
           sudo concierge prepare --trace
     - name: Run integration tests
-      run: tox -vve integration
+      run: tox -vve integration -- --model kubeflow
 
     # On failure, capture debugging resources      
     - name: Get all

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,7 @@ jobs:
       charm-path: .
 
   integration:
-    name: Integration tests (microk8s)
+    name: Integration tests
     runs-on: ubuntu-24.04
     steps:
     - name: Maximise GH runner space
@@ -80,7 +80,8 @@ jobs:
         sudo snap install concierge --classic
         sudo concierge prepare --trace
     - name: Run integration tests
-      run: tox -vve integration
+      # Running with kubeflow model because of upstream issue https://github.com/kubeflow/kubeflow/issues/7283
+      run: tox -vve integration -- --model kubeflow
 
     # On failure, capture debugging resources      
     - name: Get all

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,25 @@
+juju:
+  channel: 3.6/stable
+
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+      load-balancer:
+        enabled: true
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+    bootstrap-constraints:
+      root-disk: 4G
+
+  lxd:
+    enable: true
+    bootstrap: false
+
+host:
+  snaps:
+    charmcraft:
+      channel: 3.x/stable

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -15,7 +15,7 @@ providers:
         l2-mode: true
         cidrs: 10.64.140.43/32
     bootstrap-constraints:
-      root-disk: 4G
+      root-disk: 2G
 
   lxd:
     enable: true

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,5 +1,7 @@
 juju:
   channel: 3.6/stable
+  model-defaults:
+    logging-config: <root>=INFO; unit=DEBUG
 
 providers:
   k8s:
@@ -18,6 +20,7 @@ providers:
   lxd:
     enable: true
     bootstrap: false
+    channel: latest/stable
 
 host:
   snaps:


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1334

This PR:
- Updates the CI to use [Canonical Kubernetes](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/) instead of microk8s.
- Includes a `concierge.yaml` in the root directory for easily deploying a Canonical K8s cluster using `concierge`.
