### PR TITLE
chore: add `track/1.11` to default backport PR action

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,2 +1,3 @@
 automatic_backport_tracks:
   -   track/1.10
+  -   track/1.11


### PR DESCRIPTION
This PR adds the `track/1.11` branch to the default branches for the backport PR automation.