### PR TITLE
chore: pin charm dependencies in tests (track/1.10)

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -3,11 +3,11 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="1.24/stable", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/stable", config={"kind": "ingress"}, trust=True
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="1.24/stable",
+    channel="1.28/stable",
     config={"default-gateway": "kubeflow-gateway"},
     trust=True,
 )


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11)
- `istio-gateway`: `1.24/stable` → `1.28/stable`
- `istio-pilot`: `1.24/stable` → `1.28/stable`

Refs: canonical/bundle-kubeflow#1379
