### PR TITLE
chore: remove lib checks

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -8,20 +8,6 @@ on:
         required: true
 
 jobs:
-  lib-check:
-    name: Check libraries
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.3.0
-        with:
-          credentials: "${{ secrets.CHARMCRAFT_CREDENTIALS }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
   lint:
     name: Lint Check
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR removes the `check lib` CI job which is no longer needed.

### Removed jobs
- `lib-check` in `.github/workflows/integrate.yaml`

Refs: canonical/bundle-kubeflow#1439
